### PR TITLE
Cache: drush cr and/or drush cc wmcontroller

### DIFF
--- a/src/Service/Cache/Manager.php
+++ b/src/Service/Cache/Manager.php
@@ -99,6 +99,16 @@ class Manager implements StorageInterface
         return $results;
     }
 
+    /**
+     * Remove all cached entries.
+     *
+     * No events will be dispatched!
+     */
+    public function flush()
+    {
+        $this->storage->flush();
+    }
+
     protected function dispatch(array $items, $expired = false)
     {
         foreach ($items as $item) {

--- a/src/Service/Cache/Storage/Database.php
+++ b/src/Service/Cache/Storage/Database.php
@@ -150,6 +150,18 @@ class Database implements StorageInterface
         return $items;
     }
 
+    public function flush()
+    {
+        // Keep it transactional or risk a race with truncate?
+        $ids = $this->db->select(self::TABLE_ENTRIES, 'c')
+            ->fields('c', ['id'])
+            ->execute()->fetchCol();
+
+        while (!empty($ids)) {
+            $this->delete(array_splice($ids, 0, 50));
+        }
+    }
+
     protected function delete(array $ids)
     {
         if (empty($ids)) {

--- a/src/Service/Cache/Storage/StorageInterface.php
+++ b/src/Service/Cache/Storage/StorageInterface.php
@@ -40,4 +40,9 @@ interface StorageInterface {
      * @return Cache[] The purged cache entries.
      */
     public function purgeByTag($tag);
+
+    /**
+     * Remove all cached entries.
+     */
+    public function flush();
 }

--- a/wmcontroller.drush.inc
+++ b/wmcontroller.drush.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Implements hook_drush_cache_clear().
+ */
+function wmcontroller_drush_cache_clear(&$entries, $bootstrapped = false)
+{
+    if (!$bootstrapped) {
+        return;
+    }
+
+    $entries['wmcontroller'] = 'wmcontroller_drush_flush';
+}
+
+function wmcontroller_drush_flush()
+{
+    \Drupal::service('wmcontroller.cache.manager')->flush();
+}
+

--- a/wmcontroller.module
+++ b/wmcontroller.module
@@ -27,6 +27,18 @@ function wmcontroller_theme_set_variables(&$variables)
 }
 
 /**
+ * Implements hook_cache_flush().
+ */
+function wmcontroller_cache_flush()
+{
+    $ctr = \Drupal::getContainer();
+    if ($ctr->getParameter('wmcontroller.cache.flush_on_cache_rebuild'))
+    {
+        $ctr->get('wmcontroller.cache.manager')->flush();
+    }
+}
+
+/**
  * Implements hook_theme_registry_alter().
  */
 function wmcontroller_theme_registry_alter(&$registry)

--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -44,6 +44,9 @@ parameters:
     # is triggered.
     wmcontroller.cache.purge_per_cron: 100
 
+    # Flush all entries on `drush cr` or require `drush cc wmcontroller`
+    wmcontroller.cache.flush_on_cache_rebuild: false
+
     # List of routes that need to have their ?page= query param rewritten to a
     # route param.
     wmcontroller.pager_routes: []


### PR DESCRIPTION
so by default: only `drush cc wmcontroller` purges our caches, (or `cc all` if it were not deprecated)

to get flushes on `drush cr` requires wmcontroller.cache.flush_on_cache_rebuild to be set to `true`