### PR TITLE
Caching: route rules

### DIFF
--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -133,6 +133,15 @@ class CacheSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $smax = $request->attributes->get('_smaxage', 0);
+        $max = $request->attributes->get('_maxage', 0);
+        if ($smax || $max) {
+            $this->setMaxAge(
+                $response,
+                ['s-maxage' => $smax, 'maxage' => $max]
+            );
+        }
+
         $path = $request->getPathInfo();
         foreach ($this->expiries['paths'] as $re => $definition) {
             // # should be safe... I guess


### PR DESCRIPTION
Not sure why I ever went with path regexes... might even remove those when going to 1.0 or so

so:

```
wmcustom.search:
    path: 'search'
    defaults:
        _controller: '\Drupal\wmcustom\Controller\SearchController::index'
        _smaxage: 1234
        _maxage: 123
```