### PR TITLE
Extra cache pickups

### DIFF
--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -117,10 +117,6 @@ class CacheSubscriber implements EventSubscriberInterface
             $response->headers->set(self::CACHE_HEADER, 'MISS');
         }
 
-        if (!$response instanceof CacheableResponseInterface) {
-            return;
-        }
-
         // Don't override explicitly set maxage headers.
         if (
             $response->headers->hasCacheControlDirective('s-maxage')
@@ -133,14 +129,16 @@ class CacheSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Get max-age set in controller
-        $smax = $max = $response->getCacheableMetadata()->getCacheMaxAge();
-        if ($max !== -1) {
-            $this->setMaxAge(
-                $response,
-                ['s-maxage' => $smax, 'maxage' => $max]
-            );
-            return;
+        if ($response instanceof CacheableResponseInterface) {
+            // Get max-age defined in render array
+            $smax = $max = $response->getCacheableMetadata()->getCacheMaxAge();
+            if ($max !== -1) {
+                $this->setMaxAge(
+                    $response,
+                    ['s-maxage' => $smax, 'maxage' => $max]
+                );
+                return;
+            }
         }
 
         if ($entityExpiry = $this->getMaxAgesForMainEntity()) {

--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -129,18 +129,6 @@ class CacheSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($response instanceof CacheableResponseInterface) {
-            // Get max-age defined in render array
-            $smax = $max = $response->getCacheableMetadata()->getCacheMaxAge();
-            if ($max !== -1) {
-                $this->setMaxAge(
-                    $response,
-                    ['s-maxage' => $smax, 'maxage' => $max]
-                );
-                return;
-            }
-        }
-
         if ($entityExpiry = $this->getMaxAgesForMainEntity()) {
             $this->setMaxAge($response, $entityExpiry);
             return;

--- a/src/EventSubscriber/ViewRendererSubscriber.php
+++ b/src/EventSubscriber/ViewRendererSubscriber.php
@@ -22,7 +22,7 @@ class ViewRendererSubscriber implements EventSubscriberInterface
         $result = $event->getControllerResult();
         if ($result instanceof ViewBuilder) {
             // Replace the controller result with a render-array
-            $event->setControllerResult($result->render());
+            $event->setControllerResult($result->toRenderArray());
         }
     }
 }

--- a/src/Service/ResponseBuilder.php
+++ b/src/Service/ResponseBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\wmcontroller\Service;
+
+use Drupal\Core\Render\MainContent\HtmlRenderer;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ResponseBuilder
+{
+    /** @var \Drupal\Core\Render\MainContent\HtmlRenderer */
+    private $renderer;
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $stack;
+    /** @var \Drupal\Core\Routing\RouteMatchInterface */
+    private $routeMatch;
+
+    public function __construct(
+        HtmlRenderer $renderer,
+        RequestStack $stack,
+        RouteMatchInterface $routeMatch
+    ) {
+        $this->renderer = $renderer;
+        $this->stack = $stack;
+        $this->routeMatch = $routeMatch;
+    }
+
+    public function createResponse(
+        array $renderArray,
+        Request $request = null,
+        RouteMatchInterface $routeMatch = null
+    ) {
+        return $this->renderer->renderResponse(
+            $renderArray,
+            $request ?: $this->stack->getCurrentRequest(),
+            $routeMatch ?: $this->routeMatch
+        );
+    }
+}

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -183,6 +183,10 @@ class ViewBuilder
         return $this;
     }
 
+    /**
+     * @deprecated
+     *     Use ->toResponse()->setMaxAge($value)->setSharedMaxAge($value)
+     */
     public function setCacheMaxAge(int $context)
     {
         $this->cache['max-age'] = $context;

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -35,8 +35,6 @@ class ViewBuilder
 
     protected $headElements = [];
 
-    protected $drupalSetting = [];
-
     protected $cache = [
         'tags' => [],
         'contexts' => [],
@@ -183,21 +181,6 @@ class ViewBuilder
         return $this;
     }
 
-    public function &getDrupalSetting()
-    {
-        return $this->drupalSetting;
-    }
-
-    public function addDrupalSetting(string $key, $value)
-    {
-        if (!is_array($value) && $value instanceof \Serializable) {
-            $value = $value->serialize();
-        }
-        $this->drupalSetting[$key] = $value;
-
-        return $this;
-    }
-
     /** @deprecated Use the toRenderArray() method */
     public function render()
     {
@@ -214,7 +197,6 @@ class ViewBuilder
 
         $this->addThemeToRenderArray($view);
         $this->addHeadElementsToRenderArray($view);
-        $this->addDrupalSettingsToRenderArray($view);
         $this->addCustomHooksToRenderArray($view);
         $this->addCacheTagsToRenderArray($view);
         $this->dispatchCacheTags($view);
@@ -302,14 +284,6 @@ class ViewBuilder
                 )
             );
         }
-    }
-
-    private function addDrupalSettingsToRenderArray(&$view)
-    {
-        $view['#attached']['drupalSettings'] = array_merge(
-            $view['#attached']['drupalSettings'] ?? [],
-            $this->drupalSetting
-        );
     }
 
     private function dispatchCacheTags($view)

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -188,14 +188,14 @@ class ViewBuilder
         if ($this->entity) {
             $view = $this->createOriginalRenderArrayFromEntity($this->entity);
         }
+        $view['#_data'] = $this->data;
 
         $this->addThemeToRenderArray($view);
         $this->addHeadElementsToRenderArray($view);
         $this->addCustomHooksToRenderArray($view);
         $this->addCacheTagsToRenderArray($view);
         $this->dispatchCacheTags($view);
-
-        $view['#_data'] = $this->data;
+        $this->dispatchCacheTagsOfPassedEntities($view);
 
         return $view;
     }
@@ -280,6 +280,15 @@ class ViewBuilder
     {
         if ($view['#cache']['tags']) {
             $this->dispatcher->dispatchTags($view['#cache']['tags']);
+        }
+    }
+
+    private function dispatchCacheTagsOfPassedEntities($view)
+    {
+        foreach ($view['#_data'] as $entity) {
+            if ($entity instanceof EntityInterface) {
+                $this->dispatcher->dispatchPresented($entity);
+            }
         }
     }
 }

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -9,10 +9,10 @@ use Drupal\wmcontroller\Service\Cache\Dispatcher;
 class ViewBuilder
 {
     /** @var Dispatcher */
-    private $dispatcher;
+    protected $dispatcher;
 
     /** @var EntityTypeManagerInterface */
-    private $entityTypeManager;
+    protected $entityTypeManager;
 
     protected $viewMode = 'full';
 

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -5,6 +5,7 @@ namespace Drupal\wmcontroller\ViewBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\wmcontroller\Service\Cache\Dispatcher;
+use Drupal\wmcontroller\Service\ResponseBuilder;
 
 class ViewBuilder
 {
@@ -13,6 +14,9 @@ class ViewBuilder
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
+
+    /** @var \Drupal\wmcontroller\Service\ResponseBuilder */
+    protected $responseBuilder;
 
     protected $viewMode = 'full';
 
@@ -40,10 +44,12 @@ class ViewBuilder
 
     public function __construct(
         Dispatcher $dispatcher,
-        EntityTypeManagerInterface $entityTypeManager
+        EntityTypeManagerInterface $entityTypeManager,
+        ResponseBuilder $responseBuilder
     ) {
         $this->dispatcher = $dispatcher;
         $this->entityTypeManager = $entityTypeManager;
+        $this->responseBuilder = $responseBuilder;
     }
 
     public function setTemplateDir($templateDir)
@@ -199,7 +205,13 @@ class ViewBuilder
         return $this;
     }
 
+    /** @deprecated Use the toRenderArray() method */
     public function render()
+    {
+        return $this->toRenderArray();
+    }
+
+    public function toRenderArray()
     {
         $view = [];
         if ($this->entity) {
@@ -216,6 +228,11 @@ class ViewBuilder
         $this->dispatchCacheTagsOfPassedEntities($view);
 
         return $view;
+    }
+
+    public function toResponse()
+    {
+        return $this->responseBuilder->createResponse($this->toRenderArray());
     }
 
     private function createOriginalRenderArrayFromEntity(EntityInterface $entity)

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -79,7 +79,7 @@ class ViewBuilder
     }
 
     /**
-     * @param  array  $headElement
+     * @param  array $headElement
      * @param  string $key
      * @return $this
      */

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -183,17 +183,6 @@ class ViewBuilder
         return $this;
     }
 
-    /**
-     * @deprecated
-     *     Use ->toResponse()->setMaxAge($value)->setSharedMaxAge($value)
-     */
-    public function setCacheMaxAge(int $context)
-    {
-        $this->cache['max-age'] = $context;
-
-        return $this;
-    }
-
     public function &getDrupalSetting()
     {
         return $this->drupalSetting;

--- a/src/ViewBuilder/ViewBuilder.php
+++ b/src/ViewBuilder/ViewBuilder.php
@@ -31,6 +31,8 @@ class ViewBuilder
 
     protected $headElements = [];
 
+    protected $drupalSetting = [];
+
     protected $cache = [
         'tags' => [],
         'contexts' => [],
@@ -182,6 +184,21 @@ class ViewBuilder
         return $this;
     }
 
+    public function &getDrupalSetting()
+    {
+        return $this->drupalSetting;
+    }
+
+    public function addDrupalSetting(string $key, $value)
+    {
+        if (!is_array($value) && $value instanceof \Serializable) {
+            $value = $value->serialize();
+        }
+        $this->drupalSetting[$key] = $value;
+
+        return $this;
+    }
+
     public function render()
     {
         $view = [];
@@ -192,6 +209,7 @@ class ViewBuilder
 
         $this->addThemeToRenderArray($view);
         $this->addHeadElementsToRenderArray($view);
+        $this->addDrupalSettingsToRenderArray($view);
         $this->addCustomHooksToRenderArray($view);
         $this->addCacheTagsToRenderArray($view);
         $this->dispatchCacheTags($view);
@@ -274,6 +292,14 @@ class ViewBuilder
                 )
             );
         }
+    }
+
+    private function addDrupalSettingsToRenderArray(&$view)
+    {
+        $view['#attached']['drupalSettings'] = array_merge(
+            $view['#attached']['drupalSettings'] ?? [],
+            $this->drupalSetting
+        );
     }
 
     private function dispatchCacheTags($view)

--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -74,6 +74,10 @@ services:
         arguments: ['%wmcontroller.settings%']
         tags: [{ name: event_subscriber }]
 
+    wmcontroller.service.responsebuilder:
+        class: Drupal\wmcontroller\Service\ResponseBuilder
+        arguments: ['@main_content_renderer.html', '@request_stack', '@current_route_match']
+
     wmcontroller.renderer.viewbuilder:
         class: Drupal\wmcontroller\EventSubscriber\ViewRendererSubscriber
         tags: [{ name: event_subscriber }]
@@ -84,8 +88,11 @@ services:
 
     wmcontroller.viewbuilder:
         class: Drupal\wmcontroller\ViewBuilder\ViewBuilder
-        arguments: ['@wmcontroller.cache.dispatcher', '@entity_type.manager']
         shared: false
+        arguments:
+            - '@wmcontroller.cache.dispatcher'
+            - '@entity_type.manager'
+            - '@wmcontroller.service.responsebuilder'
 
     wmcontroller.cache.dispatcher:
         class: Drupal\wmcontroller\Service\Cache\Dispatcher


### PR DESCRIPTION
`->setCacheMaxAge()` never worked apparantly 😊 

```php
// MyController.php
public function index()
{
    return $this->view('template')->setCacheMaxAge(60);
}
```

And

```php
// MyController.php
public function index()
{
    $foobar = $this->loadEntityFromDb();
    return $this->view(
        'template',
        [
            'foo' => $foobar, // <-- This one's cache tags werent picked up
        ]
    );
}
```

`$foobar`'s cache tags weren't picked up, unless the template did an include and passed the variable.