### PR TITLE
Cache: only set max-age for:

### DIFF
--- a/src/Http/Middleware/Cache.php
+++ b/src/Http/Middleware/Cache.php
@@ -8,7 +8,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Drupal\wmcontroller\WmcontrollerEvents;
-use Drupal\Core\PageCache\RequestPolicyInterface;
 
 class Cache implements HttpKernelInterface
 {
@@ -18,17 +17,12 @@ class Cache implements HttpKernelInterface
     /** @var EventDispatcherInterface */
     protected $dispatcher;
 
-    /** @var RequestPolicyInterface */
-    protected $policy;
-
     public function __construct(
         HttpKernelInterface $next,
-        EventDispatcherInterface $dispatcher,
-        RequestPolicyInterface $policy
+        EventDispatcherInterface $dispatcher
     ) {
         $this->next = $next;
         $this->dispatcher = $dispatcher;
-        $this->policy = $policy;
     }
 
     public function handle(
@@ -36,10 +30,7 @@ class Cache implements HttpKernelInterface
         $type = self::MASTER_REQUEST,
         $catch = true
     ) {
-        if (
-            $type !== static::MASTER_REQUEST
-            || $this->policy->check($request) !== RequestPolicyInterface::ALLOW
-        ) {
+        if ($type !== static::MASTER_REQUEST) {
             return $this->next->handle($request, $type, $catch);
         }
 

--- a/src/Http/Policy/OverrideSessionPolicy.php
+++ b/src/Http/Policy/OverrideSessionPolicy.php
@@ -3,21 +3,43 @@
 namespace Drupal\wmcontroller\Http\Policy;
 
 use Drupal\Core\PageCache\RequestPolicyInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class OverrideSessionPolicy implements RequestPolicyInterface
 {
-    protected $ignoreAuthenticatedUsers;
+    /** @var AccountProxyInterface */
+    protected $account;
 
-    public function __construct($ignore)
-    {
-        $this->ignoreAuthenticatedUsers = $ignore;
+    protected $ignoreAuthenticatedUsers;
+    protected $ignoredRoles;
+
+    public function __construct(
+        AccountProxyInterface $account,
+        $ignoreAuthenticatedUsers,
+        array $ignoredRoles = []
+    ) {
+        $this->account = $account;
+        $this->ignoreAuthenticatedUsers = $ignoreAuthenticatedUsers;
+        $this->ignoredRoles = $ignoredRoles;
     }
 
     public function check(Request $request)
     {
-        if (!$this->ignoreAuthenticatedUsers) {
-            return static::ALLOW;
+        if ($this->ignoreAuthenticatedUsers) {
+            return null;
         }
+
+        if ((int) $this->account->id() === 1) {
+            return null;
+        }
+
+        $account = $this->account->getAccount();
+        $has = array_intersect($this->ignoredRoles, $account->getRoles());
+        if (!empty($has)) {
+            return null;
+        }
+
+        return static::ALLOW;
     }
 }

--- a/src/Http/Policy/OverrideSessionPolicy.php
+++ b/src/Http/Policy/OverrideSessionPolicy.php
@@ -13,12 +13,15 @@ class OverrideSessionPolicy implements RequestPolicyInterface
 
     protected $ignoreAuthenticatedUsers;
     protected $ignoredRoles;
+    protected $tags;
 
     public function __construct(
         AccountProxyInterface $account,
+        $tags,
         $ignoreAuthenticatedUsers,
         array $ignoredRoles = []
     ) {
+        $this->tags = $tags;
         $this->account = $account;
         $this->ignoreAuthenticatedUsers = $ignoreAuthenticatedUsers;
         $this->ignoredRoles = $ignoredRoles;
@@ -26,7 +29,7 @@ class OverrideSessionPolicy implements RequestPolicyInterface
 
     public function check(Request $request)
     {
-        if ($this->ignoreAuthenticatedUsers) {
+        if (!$this->tags || $this->ignoreAuthenticatedUsers) {
             return null;
         }
 

--- a/src/WmcontrollerServiceProvider.php
+++ b/src/WmcontrollerServiceProvider.php
@@ -10,8 +10,7 @@ class WmcontrollerServiceProvider implements ServiceModifierInterface
     public function alter(ContainerBuilder $container)
     {
         if (
-            $container->getParameter('wmcontroller.cache.store')
-            && $container->getParameter('wmcontroller.cache.tags')
+            $container->getParameter('wmcontroller.cache.tags')
         ) {
             $container->removeDefinition('http_middleware.page_cache');
         }

--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -59,6 +59,12 @@ parameters:
     # Disable caching for authenticated users.
     wmcontroller.cache.ignore_authenticated_users: true
 
+    # If wmcontroller.cache.ignore_authenticated_users = false
+    # don't set max-ages for these roles:
+    wmcontroller.cache.ignore_roles:
+        - 'admin'
+        - 'editor'
+
     # Amount of items that should be purged during each cron run.
     wmcontroller.cache.purge_per_cron: 100
 
@@ -144,16 +150,21 @@ services:
         class: Drupal\wmcontroller\EventSubscriber\CacheSubscriber
         arguments:
             - '@wmcontroller.cache.storage'
+            - '@current_user'
             - '%wmcontroller.cache.expiry%'
             - '%wmcontroller.cache.store%'
             - '%wmcontroller.cache.tags%'
             - '%wmcontroller.cache.hitheader%'
             - '%wmcontroller.cache.ignore_authenticated_users%'
+            - '%wmcontroller.cache.ignore_roles%'
         tags: [{ name: event_subscriber }]
 
     wmcontroller.cache.policy:
         class: Drupal\wmcontroller\Http\Policy\OverrideSessionPolicy
-        arguments: ['%wmcontroller.cache.ignore_authenticated_users%']
+        arguments:
+            - '@current_user'
+            - '%wmcontroller.cache.ignore_authenticated_users%'
+            - '%wmcontroller.cache.ignore_roles%'
         tags:
             - { name: page_cache_request_policy }
 

--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -163,6 +163,7 @@ services:
         class: Drupal\wmcontroller\Http\Policy\OverrideSessionPolicy
         arguments:
             - '@current_user'
+            - '%wmcontroller.cache.tags%'
             - '%wmcontroller.cache.ignore_authenticated_users%'
             - '%wmcontroller.cache.ignore_roles%'
         tags:
@@ -174,7 +175,7 @@ services:
 
     wmcontroller.cache.middleware:
         class: Drupal\wmcontroller\Http\Middleware\Cache
-        arguments: ['@event_dispatcher', '@page_cache_request_policy']
+        arguments: ['@event_dispatcher']
         tags:
             - { name: http_middleware, priority: 250, responder: true }
 


### PR DESCRIPTION
- anon
- users who do not have a role in wmcontroller.cache.ignore_roles
- uid 1

Only applicable when `wmcontroller.cache.ignore_authenticated_users = false`

This'll fix node operations / admin toolbar etc being cached (cdn / db) but will still result in editors receiving anon-cached versions of the page (something we can only fix with db caching while taking the user->load() performance hit).

Serving cached pages to editors is outside of wmcontrollers scope anyhoo, so a direct url is still required.

