### PR TITLE
Listen to what the responseCachePolicy says ( drupal_set_message )

### DIFF
--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -151,6 +151,7 @@ services:
         arguments:
             - '@wmcontroller.cache.storage'
             - '@current_user'
+            - '@page_cache_response_policy'
             - '%wmcontroller.cache.expiry%'
             - '%wmcontroller.cache.store%'
             - '%wmcontroller.cache.tags%'


### PR DESCRIPTION
The page_cache_response_policy determines the cacheablitity of a response.
It's set to DENY when drupal_set_message has been called.

Also added an option to redirect to the a route when visiting
a node that's not translated in the current language.