### PR TITLE
Stop extending the core ControllerBase

### DIFF
--- a/src/Controller/ControllerBase.php
+++ b/src/Controller/ControllerBase.php
@@ -2,11 +2,15 @@
 
 namespace Drupal\wmcontroller\Controller;
 
-use Drupal\Core\Controller\ControllerBase as DrupalControllerBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
 use Drupal\wmcontroller\ViewBuilder\ViewBuilder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
-abstract class ControllerBase extends DrupalControllerBase
+abstract class ControllerBase
 {
+    use StringTranslationTrait;
+
     protected $templateDir = '';
 
     /**
@@ -22,6 +26,31 @@ abstract class ControllerBase extends DrupalControllerBase
             ->setTemplateDir($this->templateDir)
             ->setData($data)
             ->setTemplate($template);
+    }
+
+    /**
+     * Returns a redirect response object for the specified route.
+     *
+     * @param string $routeName
+     *   The name of the route to which to redirect.
+     * @param array $routeParameters
+     *   (optional) Parameters for the route.
+     * @param array $options
+     *   (optional) An associative array of additional options.
+     * @param int $status
+     *   (optional) The HTTP redirect status code for the redirect. The default is
+     *   302 Found.
+     *
+     * @return RedirectResponse
+     *   A redirect response object that may be returned by the controller.
+     */
+    protected function redirect($routeName, array $routeParameters = [], array $options = [], $status = 302)
+    {
+        $url = Url::fromRoute($routeName, $routeParameters, $options)
+            ->setAbsolute(true)
+            ->toString();
+
+        return new RedirectResponse($url, $status);
     }
 }
 


### PR DESCRIPTION
+ include `Drupal\Core\StringTranslation\StringTranslationTrait`
+ include a redirect helper previously in `Drupal\Core\Routing\UrlGeneratorTrait`, but since this is deprecated we will not be adding it