### PR TITLE
Bump requirements to PHP 8.0 and Drupal 9.1

### DIFF
--- a/.php_cs.php
+++ b/.php_cs.php
@@ -1,9 +1,9 @@
 <?php
 
 use Wieni\wmcodestyle\PhpCsFixer\Config\Factory;
-use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php71;
+use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php80;
 
-$config = Factory::fromRuleSet(new Php71);
+$config = Factory::fromRuleSet(new Php80);
 
 $config->getFinder()
     ->ignoreVCSIgnored(true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [0.11.0] - 2021-08-24
 ### Added
 - Add support for all entities with canonical routes
 - Add issue & pull request templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.11.0] - 2021-08-24
+## [1.0.0] - 2021-08-24
 ### Added
 - Add support for all entities with canonical routes
 - Add issue & pull request templates
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Drupal 9 support
 
 ### Changed
-- Increase PHP dependency to 7.1
+- Increase PHP dependency to 8.0
 - Update module name & description
 - Make bundle-specific controllers optional, falling back to the default 
  controller

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "wieni/wmcontroller",
     "type": "drupal-module",
-    "description": "Adds support for bundle-specific controllers for Drupal 8 entities.",
+    "description": "Adds support for bundle-specific controllers for Drupal 9 entities.",
     "license": "MIT",
     "authors": [
         {
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "drupal/core": "^8.6 || ^9.0"
+        "drupal/core": "^9.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": "^8.0",
         "drupal/core": "^9.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",
-        "wieni/wmcodestyle": "^1.0"
+        "wieni/wmcodestyle": "^1.7"
     },
     "extra": {
         "drush": {

--- a/src/Event/CacheInsertEvent.php
+++ b/src/Event/CacheInsertEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmcontroller\Event;
 
 use Drupal\wmcontroller\Entity\Cache;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Event/CacheTagsEvent.php
+++ b/src/Event/CacheTagsEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\wmcontroller\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class CacheTagsEvent extends Event
 {

--- a/src/Event/EntityPresentedEvent.php
+++ b/src/Event/EntityPresentedEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmcontroller\Event;
 
 use Drupal\Core\Entity\EntityInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class EntityPresentedEvent extends Event
 {

--- a/src/Event/MainEntityEvent.php
+++ b/src/Event/MainEntityEvent.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\wmcontroller\Event;
 
+use Drupal\Component\EventDispatcher\Event;
 use Drupal\Core\Entity\EntityInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 class MainEntityEvent extends Event
 {

--- a/src/Event/PresentedEvent.php
+++ b/src/Event/PresentedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\wmcontroller\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class PresentedEvent extends Event
 {

--- a/src/Event/ValidationEvent.php
+++ b/src/Event/ValidationEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\wmcontroller\Event;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\wmcontroller\Service\Cache\Validation\ValidationResult;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -47,7 +47,7 @@ class CacheSubscriber implements EventSubscriberInterface
         Validation $validation,
         EnrichRequest $enrichRequest,
         MaxAgeInterface $maxAgeStrategy,
-        $addHeader = false,
+        bool $addHeader,
         array $strippedHeaders
     ) {
         $this->manager = $manager;

--- a/src/Http/Middleware/Cache.php
+++ b/src/Http/Middleware/Cache.php
@@ -5,7 +5,7 @@ namespace Drupal\wmcontroller\Http\Middleware;
 use Drupal\wmcontroller\WmcontrollerEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Cache implements HttpKernelInterface
@@ -33,11 +33,11 @@ class Cache implements HttpKernelInterface
             return $this->next->handle($request, $type, $catch);
         }
 
-        $event = new GetResponseEvent($this, $request, $type);
+        $event = new RequestEvent($this, $request, $type);
 
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::CACHE_HANDLE,
-            $event
+            $event,
+            WmcontrollerEvents::CACHE_HANDLE
         );
 
         if ($event->hasResponse()) {

--- a/src/Service/Cache/Dispatcher.php
+++ b/src/Service/Cache/Dispatcher.php
@@ -34,8 +34,8 @@ class Dispatcher
     {
         $event = new MainEntityEvent($entity);
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::MAIN_ENTITY_RENDER,
-            $event
+            $event,
+            WmcontrollerEvents::MAIN_ENTITY_RENDER
         );
 
         return $event;
@@ -46,8 +46,8 @@ class Dispatcher
     {
         $event = new EntityPresentedEvent($entity);
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::ENTITY_PRESENTED,
-            $event
+            $event,
+            WmcontrollerEvents::ENTITY_PRESENTED
         );
 
         return $event;
@@ -58,8 +58,8 @@ class Dispatcher
     {
         $event = new CacheTagsEvent($tags);
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::CACHE_TAGS,
-            $event
+            $event,
+            WmcontrollerEvents::CACHE_TAGS
         );
 
         return $event;
@@ -74,8 +74,8 @@ class Dispatcher
     ) {
         $event = new CacheInsertEvent($cache, $tags, $request, $response);
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::CACHE_INSERT,
-            $event
+            $event,
+            WmcontrollerEvents::CACHE_INSERT
         );
 
         return $event;
@@ -90,8 +90,8 @@ class Dispatcher
             CacheableRequestResult::class
         );
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::VALIDATE_CACHEABILITY_REQUEST,
-            $event
+            $event,
+            WmcontrollerEvents::VALIDATE_CACHEABILITY_REQUEST
         );
         return $event;
     }
@@ -105,8 +105,8 @@ class Dispatcher
             CacheableResponseResult::class
         );
         $this->dispatcher->dispatch(
-            WmcontrollerEvents::VALIDATE_CACHEABILITY_RESPONSE,
-            $event
+            $event,
+            WmcontrollerEvents::VALIDATE_CACHEABILITY_RESPONSE
         );
         return $event;
     }

--- a/src/Twig/Template.php
+++ b/src/Twig/Template.php
@@ -29,8 +29,8 @@ abstract class Template extends \Twig_Template
         foreach ($context as $k => $var) {
             $event = new PresentedEvent($var);
             $this->getDispatcher()->dispatch(
-                WmcontrollerEvents::PRESENTED,
-                $event
+                $event,
+                WmcontrollerEvents::PRESENTED
             );
 
             $context[$k] = $event->getItem();


### PR DESCRIPTION
Some deprecations are being thrown now and its a pain to provide a backwards compatible solution.

See https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407

This MR will bump the composer requirement to Drupal 9.1 and PHP 8.0

- Fix "Required argument $strippedHeaders after optional argument"