### PR TITLE
Support stale-while-revalidate and stale-if-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.1] - 2023-07-19
+### Added
+- Support `stale-while-revalidate` and `stale-if-error` cache control header
+  - [https://developer.fastly.com/learning/concepts/stale](http://web.archive.org/web/20230719193134/https://developer.fastly.com/learning/concepts/stale/)
+
 ## [1.1.0] - 2022-06-28
 ### Added
 - Add v2 upgrade guide & script

--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -233,11 +233,19 @@ class CacheSubscriber implements EventSubscriberInterface
             $response->setSharedMaxAge($definition['s-maxage']);
         }
 
-        if (isset($definition['wm-s-maxage'])) {
-            $response->headers->addCacheControlDirective(
-                'wm-s-maxage',
-                $definition['wm-s-maxage']
-            );
+        $directives = [
+            'wm-s-maxage',
+            'stale-while-revalidate',
+            'stale-if-error',
+        ];
+
+        foreach ($directives as $directive) {
+            if (isset($definition[$directive])) {
+                $response->headers->addCacheControlDirective(
+                    $directive,
+                    $definition[$directive]
+                );
+            }
         }
     }
 }

--- a/src/Service/Cache/MaxAgeDecider.php
+++ b/src/Service/Cache/MaxAgeDecider.php
@@ -49,6 +49,8 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
                 'maxage' => $headers->getCacheControlDirective('max-age'),
                 's-maxage' => $headers->getCacheControlDirective('s-maxage'),
                 'wm-s-maxage' => $headers->getCacheControlDirective('wm-s-maxage'),
+                'stale-while-revalidate' => $headers->getCacheControlDirective('stale-while-revalidate'),
+                'stale-if-error' => $headers->getCacheControlDirective('stale-if-error'),
             ],
             static fn ($value) => $value !== null
         );
@@ -75,6 +77,8 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
                 's-maxage' => $request->attributes->get('_smaxage', 0),
                 'maxage' => $request->attributes->get('_maxage', 0),
                 'wm-s-maxage' => $request->attributes->get('_wmsmaxage', null),
+                'stale-while-revalidate' => $request->attributes->get('_stale-while-revalidate', null),
+                'stale-if-error' => $request->attributes->get('_stale-if-error', null),
             ];
         }
 
@@ -92,7 +96,13 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
             return $explicit + $definition;
         }
 
-        return $explicit + ['s-maxage' => 0, 'maxage' => 0, 'wm-s-maxage' => null];
+        return $explicit + [
+            's-maxage' => 0,
+            'maxage' => 0,
+            'wm-s-maxage' => null,
+            'stale-while-revalidate' => null,
+            'stale-if-error' => null,
+        ];
     }
 
     protected function getMaxAgesForMainEntity()

--- a/wmcontroller.services.yml
+++ b/wmcontroller.services.yml
@@ -30,6 +30,8 @@ parameters:
     # maxage = client side caching duration
     # s-maxage = server side caching duration (this can be drupal db or a cdn)
     # wm-s-maxage = custom cache-control directive for different local cache ttl
+    # stale-while-revalidate indicates that caches MAY serve the response after it becomes stale, up to the indicated number of seconds.
+    # stale-if-error indicates that when an error is encountered, a cached stale response MAY be used to satisfy the request, up to the indicated number of seconds.
     wmcontroller.cache.expiry:
         # Determine max and s-max based on content-type and/or bundle.
         # _default is used when no definition is available for any given bundle.
@@ -40,8 +42,9 @@ parameters:
                 #   Client side caching for 2 minutes
                 #   CDN caching for 5 minutes
                 #   Local db caching for 1 hour
+                #   Serve stale content for 1 day, while revalidating in the background
                 #
-                # article: { maxage: 120, s-maxage: 300, wm-s-maxage: 3600 }
+                # article: { maxage: 120, s-maxage: 300, wm-s-maxage: 3600, stale-while-revalidate: 86400, stale-if-error: 86400 }
             taxonomy_term:
                 _default: { maxage: 120, s-maxage: 300 }
 


### PR DESCRIPTION
## Description

[Fastly has written a nice explanation about the `stale-while-revalidate` and `stale-if-error` cache control extensions.](http://web.archive.org/web/20230719193134/https://developer.fastly.com/learning/concepts/stale/)

The `stale-while-revalidate` cache control extension indicates to caches that they MAY serve stale content while they revalidate in the background. This can be useful for content that is not time-sensitive, or for which it is acceptable to
serve slightly out-of-date content while a new version is being fetched.

The `stale-if-error` cache control extension indicates that when an error is encountered, a cached stale response MAY be used to satisfy the request. For example when a project is in maintenance mode during deployment, caches can serve stale content instead of returning the maintenance error page.

Both these extensions are getting more and more adopted by CDNs; including Fastly, Cloudflare and CloudFront.

### Documentation

These are regular cache control extensions, so they can be defined like you already define the `s-maxage` directive.

#### In the `services.yml`

```diff
wmcontroller.cache.expiry:
    entities:
        node:
-           _default: { maxage: 120, s-maxage: 300 }
+           _default: { maxage: 120, s-maxage: 300, stale-while-revalidate: 86400, stale-if-error: 86400 }
        taxonomy_term:
-           _default: { maxage: 120, s-maxage: 300 }
+           _default: { maxage: 120, s-maxage: 300, stale-while-revalidate: 86400, stale-if-error: 86400 }
```

#### In the `routing.yml`

```diff
my_module.my_route:
    path: '/my-path'
    defaults:
        _controller: '\Drupal\my_module\Controller\MyController::myAction'
        _maxage: 60
        _smaxage: 3600
+       _stale-while-revalidate: 86400
+       _stale-if-error: 86400
```

#### On a Response object

```diff
// my_module/src/Controller/MyController.php
public function myAction(): Response
{
    $response = new Response('foobar');
    $response->setMaxAge(300);
    $response->setSharedMaxAge(3600 * 12);
+   $response->headers->addCacheControlDirective('stale-while-revalidate', 86400);
+   $response->headers->addCacheControlDirective('stale-if-error', 86400);

    return $response
}
```
