### PR TITLE
Change namespace of moved class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.1] - 2023-10-30
+### Fixed
+- Mark http responses with status codes `300`, `301`, `302` and `410` cacheable
+
 ## [1.2.0] - 2023-09-13
 ### Added
 - Add Drupal 10 support. Drop Drupal 9 support.

--- a/src/Service/Cache/Validation/Validation.php
+++ b/src/Service/Cache/Validation/Validation.php
@@ -17,7 +17,11 @@ class Validation implements EventSubscriberInterface
     protected $cacheableStatusCodes = [
         Response::HTTP_OK => true,
         Response::HTTP_NON_AUTHORITATIVE_INFORMATION => true,
+        Response::HTTP_MULTIPLE_CHOICES => true,
+        Response::HTTP_MOVED_PERMANENTLY => true,
+        Response::HTTP_FOUND => true,
         Response::HTTP_NOT_FOUND => true,
+        Response::HTTP_GONE => true,
     ];
 
     protected $cacheableMethods = [


### PR DESCRIPTION
The current implementation doesn't cache all kinds of responses.
This PR makes sure the following statuscodes are now considered cacheable as well, in addition to the already considered cacheable codes `200`, `203` and `404`:

| Code | Description |
|------|-|
| 300  | Multiple Choices |
| 301  | Moved Permanently |
| 302  | Found |
| 410  | Gone |

This list has been taken [from Symfony](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/Response.php#L569-L580).

After this PR is merged, you can cache redirect responses.